### PR TITLE
FEAT - Jacoco test coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,22 @@ install:
 
 script:
   - cat target/test-results/index.html
+
+addons:
+  coverity_scan:
+    project:
+      name: "veraPDF/veraPDF-integration-tests"
+      description: "Industry supported, open source PDF/A validation"
+      notification_email: carl@openpreservation.org
+    build_command_prepend: "mvn clean"
+    build_command:   "mvn -DskipTests=true compile"
+    branch_pattern: integration
+
+before_install:
+- curl -sL https://github.com/jpm4j/jpm4j.installers/raw/master/dist/biz.aQute.jpm.run.jar >jpm4j.jar
+- java -jar jpm4j.jar -u init
+- ~/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly
+
+after_success:
+- bash <(curl -s https://codecov.io/bash)
+- ~/jpm/bin/codacy-coverage-reporter -l Java -r jhove-apps/target/site/jacoco/jacoco.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ before_install:
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- ~/jpm/bin/codacy-coverage-reporter -l Java -r jhove-apps/target/site/jacoco/jacoco.xml
+- ~/jpm/bin/codacy-coverage-reporter -l Java -r target/site/jacoco/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,7 @@
   </pluginRepositories>
 
   <properties>
-    <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
-    <sonar.language>java</sonar.language>
+    <jacoco.version>0.7.9</jacoco.version>
     <verapdf.library.version>[1.3.0,1.4.0)</verapdf.library.version>
     <verapdf.pdfbox.validation.version>[1.3.0,1.4.0)</verapdf.pdfbox.validation.version>
     <verapdf.validation.version>[1.3.0,1.4.0)</verapdf.validation.version>
@@ -117,116 +116,57 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
+      <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-dependency-plugin</artifactId>
+         <version>3.0.0</version>
+         <executions>
+           <execution>
+             <id>unpack</id>
+             <phase>test</phase>
+             <goals>
+               <goal>unpack-dependencies</goal>
+             </goals>
+             <configuration>
+               <overWrite>true</overWrite>
+               <outputDirectory>${project.build.directory}/classes</outputDirectory>
+               <overWriteReleases>false</overWriteReleases>
+               <overWriteSnapshots>true</overWriteSnapshots>
+             </configuration>
+           </execution>
+         </executions>
+       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
-
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19.1</version>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <configuration>
+          <sessionId>${project.artifactId}</sessionId>
+          <includes>
+            <include>org/verapdf/**</include>
+          </includes>
+        </configuration>
         <executions>
           <execution>
-            <id>integration-test</id>
+            <id>prepare</id>
             <goals>
-              <goal>integration-test</goal>
+              <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
-            <id>verify</id>
+            <id>report</id>
             <goals>
-              <goal>verify</goal>
+              <goal>report-aggregate</goal>
             </goals>
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <configuration>
-          <!-- The destination file for the code coverage report has to be set to
-            the same value in the parent pom and in each module pom. Then JaCoCo will add up
-            information in the same report, so that, it will give the cross-module code coverage. -->
-          <destFile>${project.basedir}/target/jacoco-it.exec</destFile>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-          <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-        </configuration>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>index</report>
-              <report>dependencies</report>
-              <report>project-team</report>
-              <report>mailing-list</report>
-              <report>cim</report>
-              <report>issue-tracking</report>
-              <report>license</report>
-              <report>scm</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
-        <configuration>
-          <show>public</show>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
-
-
-  <profiles>
-
-    <profile>
-      <id>coverage-per-test</id>
-      <build>
-        <plugins>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-
-              <properties>
-                <property>
-                  <name>listener</name>
-                  <value>org.sonar.java.jacoco.JUnitListener</value>
-                </property>
-              </properties>
-
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-      <dependencies>
-
-        <dependency>
-          <groupId>org.codehaus.sonar-plugins.java</groupId>
-          <artifactId>sonar-jacoco-listeners</artifactId>
-          <version>1.2</version>
-          <scope>test</scope>
-        </dependency>
-
-      </dependencies>
-    </profile>
-
-  </profiles>
 </project>


### PR DESCRIPTION
- added dependency download to POM so Jacoco reports their coverage; and
- added test data upload information to `.travis.yml`.