### PR TITLE
FIX - Catch & Report Validation Exceptions

### DIFF
--- a/src/main/java/org/verapdf/pdfa/qa/ResultSet.java
+++ b/src/main/java/org/verapdf/pdfa/qa/ResultSet.java
@@ -176,13 +176,13 @@ public interface ResultSet {
 	 */
 	public static class Incomplete {
 		private final CorpusItemId corpusItemId;
-		private final Exception cause;
+		private final Throwable cause;
 
 		/**
 		 * @param corpusItem
 		 * @param cause
 		 */
-		public Incomplete(final CorpusItemId corpusItemId, final Exception cause) {
+		public Incomplete(final CorpusItemId corpusItemId, final Throwable cause) {
 			this.corpusItemId = corpusItemId;
 			this.cause = cause;
 		}
@@ -197,7 +197,7 @@ public interface ResultSet {
 		/**
 		 * @return the cause
 		 */
-		public Exception getCause() {
+		public Throwable getCause() {
 			return this.cause;
 		}
 

--- a/src/main/java/org/verapdf/pdfa/qa/ResultSetImpl.java
+++ b/src/main/java/org/verapdf/pdfa/qa/ResultSetImpl.java
@@ -207,8 +207,9 @@ public class ResultSetImpl implements ResultSet {
 					maxMemUse = (memUsed > maxMemUse) ? memUsed : maxMemUse;
 					results.add(new Result(id, result, jobTimer.stop(), memUsed));
 				} catch (Throwable e) {
-					LOG.log(Level.SEVERE, String.format("Caught throwable testing %s from corpus %s", itemName,
-							corpus.getDetails().getName()), e);
+					LOG.log(Level.SEVERE, String.format("Caught throwable testing %s from corpus %s", itemName));
+					LOG.log(Level.SEVERE, e.getClass().getName()); 
+					LOG.log(Level.SEVERE, e.getMessage()); 
 					exceptions.add(new Incomplete(id, e));
 				}
 			}

--- a/src/main/java/org/verapdf/pdfa/qa/ResultSetImpl.java
+++ b/src/main/java/org/verapdf/pdfa/qa/ResultSetImpl.java
@@ -207,9 +207,10 @@ public class ResultSetImpl implements ResultSet {
 					maxMemUse = (memUsed > maxMemUse) ? memUsed : maxMemUse;
 					results.add(new Result(id, result, jobTimer.stop(), memUsed));
 				} catch (Throwable e) {
-					LOG.log(Level.SEVERE, String.format("Caught throwable testing %s from corpus %s", itemName));
-					LOG.log(Level.SEVERE, e.getClass().getName()); 
-					LOG.log(Level.SEVERE, e.getMessage()); 
+					LOG.log(Level.SEVERE, String.format("Caught throwable testing %s from corpus %s", itemName,
+							corpus.getDetails().getName()));
+					LOG.log(Level.SEVERE, e.getClass().getName());
+					LOG.log(Level.SEVERE, e.getMessage());
 					exceptions.add(new Incomplete(id, e));
 				}
 			}

--- a/src/main/java/org/verapdf/pdfa/qa/ResultSetImpl.java
+++ b/src/main/java/org/verapdf/pdfa/qa/ResultSetImpl.java
@@ -1,22 +1,16 @@
 /**
- * This file is part of veraPDF Quality Assurance, a module of the veraPDF project.
- * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org>
- * All rights reserved.
- *
- * veraPDF Quality Assurance is free software: you can redistribute it and/or modify
- * it under the terms of either:
- *
- * The GNU General public license GPLv3+.
- * You should have received a copy of the GNU General Public License
- * along with veraPDF Quality Assurance as the LICENSE.GPL file in the root of the source
- * tree.  If not, see http://www.gnu.org/licenses/ or
- * https://www.gnu.org/licenses/gpl-3.0.en.html.
- *
- * The Mozilla Public License MPLv2+.
- * You should have received a copy of the Mozilla Public License along with
- * veraPDF Quality Assurance as the LICENSE.MPL file in the root of the source tree.
- * If a copy of the MPL was not distributed with this file, you can obtain one at
- * http://mozilla.org/MPL/2.0/.
+ * This file is part of veraPDF Quality Assurance, a module of the veraPDF
+ * project. Copyright (c) 2015, veraPDF Consortium <info@verapdf.org> All rights
+ * reserved. veraPDF Quality Assurance is free software: you can redistribute it
+ * and/or modify it under the terms of either: The GNU General public license
+ * GPLv3+. You should have received a copy of the GNU General Public License
+ * along with veraPDF Quality Assurance as the LICENSE.GPL file in the root of
+ * the source tree. If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html. The Mozilla Public License
+ * MPLv2+. You should have received a copy of the Mozilla Public License along
+ * with veraPDF Quality Assurance as the LICENSE.MPL file in the root of the
+ * source tree. If a copy of the MPL was not distributed with this file, you can
+ * obtain one at http://mozilla.org/MPL/2.0/.
  */
 /**
  * 
@@ -212,7 +206,9 @@ public class ResultSetImpl implements ResultSet {
 					long memUsed = (ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / MEGABYTE);
 					maxMemUse = (memUsed > maxMemUse) ? memUsed : maxMemUse;
 					results.add(new Result(id, result, jobTimer.stop(), memUsed));
-				} catch (Exception e) {
+				} catch (Throwable e) {
+					LOG.log(Level.SEVERE, String.format("Caught throwable testing %s from corpus %s", itemName,
+							corpus.getDetails().getName()), e);
 					exceptions.add(new Incomplete(id, e));
 				}
 			}

--- a/src/test/java/org/verapdf/integration/CorpusTest.java
+++ b/src/test/java/org/verapdf/integration/CorpusTest.java
@@ -1,24 +1,20 @@
 /**
- * This file is part of veraPDF Quality Assurance, a module of the veraPDF project.
- * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org>
- * All rights reserved.
- *
- * veraPDF Quality Assurance is free software: you can redistribute it and/or modify
- * it under the terms of either:
- *
- * The GNU General public license GPLv3+.
- * You should have received a copy of the GNU General Public License
- * along with veraPDF Quality Assurance as the LICENSE.GPL file in the root of the source
- * tree.  If not, see http://www.gnu.org/licenses/ or
- * https://www.gnu.org/licenses/gpl-3.0.en.html.
- *
- * The Mozilla Public License MPLv2+.
- * You should have received a copy of the Mozilla Public License along with
- * veraPDF Quality Assurance as the LICENSE.MPL file in the root of the source tree.
- * If a copy of the MPL was not distributed with this file, you can obtain one at
- * http://mozilla.org/MPL/2.0/.
+ * This file is part of veraPDF Quality Assurance, a module of the veraPDF
+ * project. Copyright (c) 2015, veraPDF Consortium <info@verapdf.org> All rights
+ * reserved. veraPDF Quality Assurance is free software: you can redistribute it
+ * and/or modify it under the terms of either: The GNU General public license
+ * GPLv3+. You should have received a copy of the GNU General Public License
+ * along with veraPDF Quality Assurance as the LICENSE.GPL file in the root of
+ * the source tree. If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html. The Mozilla Public License
+ * MPLv2+. You should have received a copy of the Mozilla Public License along
+ * with veraPDF Quality Assurance as the LICENSE.MPL file in the root of the
+ * source tree. If a copy of the MPL was not distributed with this file, you can
+ * obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.verapdf.integration;
+
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -74,6 +70,7 @@ public class CorpusTest {
 		PdfBoxFoundryProvider.initialise();
 		pdfBoxDetails = Foundries.defaultInstance().getDetails();
 		testCorpora(pdfBoxResults);
+		assertFalse(countExceptions(pdfBoxResults) > 0);
 	}
 
 	@Test
@@ -81,18 +78,30 @@ public class CorpusTest {
 		VeraGreenfieldFoundryProvider.initialise();
 		gfDetails = Foundries.defaultInstance().getDetails();
 		testCorpora(gfResults);
+		assertFalse(countExceptions(gfResults) > 0);
+	}
+	
+	private static int countExceptions(final List<ResultSet> resultSets) {
+		int exceptionCount = 0;
+		for (ResultSet set : resultSets) {
+			exceptionCount += set.getExceptions().size();
+		}
+		return exceptionCount;
 	}
 
-	private static void testCorpora(List<ResultSet> resultSets) {
+	private static void testCorpora(final List<ResultSet> resultSets) {
 		for (PDFAFlavour flavour : CorpusManager.testableFlavours()) {
 			for (TestCorpus corpus : CorpusManager.corporaForFlavour(flavour)) {
-				PDFAValidator validator = Foundries.defaultInstance().createValidator(flavour, false);
-				ResultSet results = ResultSetImpl.validateCorpus(corpus, validator);
-				resultSets.add(results);
+				try (PDFAValidator validator = Foundries.defaultInstance().createValidator(flavour, false)) {
+					ResultSet results = ResultSetImpl.validateCorpus(corpus, validator);
+					resultSets.add(results);
+				} catch (IOException excep) {
+					// Just exception closing validator
+					excep.printStackTrace();
+				}
 			}
 		}
 	}
-
 
 	/**
 	 * Tests the passed String {@code parseForMatches} and returns true if
@@ -119,7 +128,7 @@ public class CorpusTest {
 			rootDir.mkdirs();
 		writeSummaries(rootDir);
 		int index = 0;
-		for (ResultSet pdfBoxResult  : pdfBoxResults) {
+		for (ResultSet pdfBoxResult : pdfBoxResults) {
 			ResultSet gfResult = gfResults.get(index++);
 			Map<String, Object> scopes = new HashMap<>();
 			scopes.put("pdfBoxResult", pdfBoxResult);


### PR DESCRIPTION
First I've extended `ResultSet` validation error handling to catch all `Throwables`.
This prevents the process failing for type like `java.lang.IllegalAccessError` that
crashed the tests.
- extended exception handling;
- added simple check for number of exceptions for corpora; and
- tests now fail if any exceptions thrown to prevent apps building.