### PR TITLE
REL - Development version v1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk7
+  - openjdk8
   - oraclejdk8
 
 branches:

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
   <parent>
     <artifactId>verapdf-parent</artifactId>
     <groupId>org.verapdf</groupId>
-    <version>1.4.1</version>
+    <version>1.12.2</version>
   </parent>
 
   <groupId>org.verapdf</groupId>
   <artifactId>verapdf-integration-tests</artifactId>
-  <version>1.10.0</version>
+  <version>1.11.0-SNAPSHOT</version>
   <name>veraPDF Quality Assurance</name>
   <description>Test and QA utilities for the veraPDF Library.</description>
 
@@ -64,9 +64,9 @@
 
   <properties>
     <jacoco.version>0.7.9</jacoco.version>
-    <verapdf.library.version>[1.10.0,1.11.0)</verapdf.library.version>
-    <verapdf.pdfbox.validation.version>[1.10.0,1.11.0)</verapdf.pdfbox.validation.version>
-    <verapdf.validation.version>[1.10.0,1.11.0)</verapdf.validation.version>
+    <verapdf.library.version>[1.11.0,1.12.0)</verapdf.library.version>
+    <verapdf.pdfbox.validation.version>[1.11.0,1.12.0)</verapdf.pdfbox.validation.version>
+    <verapdf.validation.version>[1.11.0,1.12.0)</verapdf.validation.version>
   </properties>
 
   <dependencies>
@@ -89,17 +89,17 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.10</version>
+      <version>1.11</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.54</version>
+      <version>1.58</version>
     </dependency>
     <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>
       <artifactId>compiler</artifactId>
-      <version>0.8.18</version>
+      <version>0.9.5</version>
     </dependency>
     <dependency>
       <groupId>org.verapdf</groupId>
@@ -119,7 +119,7 @@
       <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-dependency-plugin</artifactId>
-         <version>3.0.0</version>
+         <version>3.0.2</version>
          <executions>
            <execution>
              <id>unpack</id>


### PR DESCRIPTION
- bumped minor -> 1.11 for development;
- upgraded Travis OpenJDK build to Java 8;
- using parent pom v1.12.2 for Java 8 build; and
- updated Maven plugins to latest versions.