### PR TITLE
Update verapdf-parent pom.xml version to 1.29.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>verapdf-parent</artifactId>
     <groupId>org.verapdf</groupId>
-    <version>1.29.1</version>
+    <version>1.29.6</version>
   </parent>
 
   <artifactId>verapdf-integration-tests</artifactId>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated parent dependency version from 1.29.1 to 1.29.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->